### PR TITLE
treble: Initial Implementation of checkhealth Command

### DIFF
--- a/lua/treble/health.lua
+++ b/lua/treble/health.lua
@@ -1,0 +1,20 @@
+local health = vim.health
+
+local M = {}
+
+local function check_for_plugin(plugin_name)
+  local plugin = require(plugin_name)
+  if plugin ~= nil then
+    health.report_ok(plugin_name .. " is installed")
+  else
+    health.report_error(plugin_name .. " is missing")
+  end
+end
+
+M.check = function()
+  health.report_start("Checking for required plugins")
+  check_for_plugin("telescope")
+  check_for_plugin("bufferline")
+end
+
+return M


### PR DESCRIPTION
Problem

It's good practice for a Neovim plugin to implement a plugin-specific `checkhealth` command and treble currently does not have one.

Solution

Implement a `health` module for treble, which is what the `checkhealth` command uses.

Result

Running the `checkhealth` command for treble, i.e. `checkhealth treble` will indicate that `telescope` and `bufferline` are installed correctly when they can be loaded. However, if there is a problem with either dependency, then `treble` will fail to load at all. That behavior will be fixed in a future change.