### PR TITLE
treble: Treble Should Load Regardless of Missing Dependencies

### DIFF
--- a/lua/treble/init.lua
+++ b/lua/treble/init.lua
@@ -2,13 +2,6 @@ local M = {}
 
 local vim = vim
 
-local pickers = require("telescope.pickers")
-local entry_display = require("telescope.pickers.entry_display")
-local actions = require("telescope.actions")
-local action_state = require("telescope.actions.state")
-local finders = require("telescope.finders")
-local config = require("telescope.config")
-
 local function list_buffers()
   local utils = require("bufferline.utils")
   return utils.get_valid_buffers()
@@ -73,6 +66,13 @@ end
 
 local function buffers(opts)
   opts = opts or {}
+
+  local pickers = require("telescope.pickers")
+  local entry_display = require("telescope.pickers.entry_display")
+  local actions = require("telescope.actions")
+  local action_state = require("telescope.actions.state")
+  local finders = require("telescope.finders")
+  local config = require("telescope.config")
 
   local buffer_numbers = list_buffers()
   local sorted_buffers = sort_buffers(buffer_numbers)


### PR DESCRIPTION
Problem

If the `bufferline` or `telescope` plugins are missing, then `treble` fails to load at all. That's not ideal, and instead `treble` should be able to load initially, and just not work properly. Additionally, the `checkhealth` command should indicate that the required dependencies are missing.

Solution

Move the loading of the `bufferline` and `telescope` plugins to inside the `buffers` function instead of being part of the initial plugin loading.

Result

`treble` will load regardless of whether the `bufferline` and `telescope` plugins are missing. Additional work should be done to improve the display of the `checkhealth` command when they are missing though.