### PR TITLE
treble: Buffers without a Name Should Display as "[No Name]"

### DIFF
--- a/lua/treble/init.lua
+++ b/lua/treble/init.lua
@@ -18,8 +18,16 @@ local function sort_buffers(buffer_numbers)
   return result
 end
 
+local function is_empty(s)
+  return s == nil or s == ''
+end
+
 local function get_buffer_name(buffer_number)
-  return vim.api.nvim_buf_get_name(buffer_number)
+  local name = vim.api.nvim_buf_get_name(buffer_number)
+  if is_empty(name) then
+    name = "[No Name]"
+  end
+  return name
 end
 
 local function buffer_file_name(buffer_name)


### PR DESCRIPTION
Problem

When a buffer does not have a name, which may happen on initial startup, `bufferline` displays the buffer name as "[No Name]", whereas `treble` displays the name as "". These should match, and they don't.

Solution

Modify `treble` shuch that buffers without a name display as "[No Name]" and not "".

Result

`bufferline` and `treble` display a consistent name for buffers without a name.