### PR TITLE
treble: Fix HealthCheck to Report Errors and Not Cause Errors

### DIFF
--- a/lua/treble/health.lua
+++ b/lua/treble/health.lua
@@ -3,8 +3,8 @@ local health = vim.health
 local M = {}
 
 local function check_for_plugin(plugin_name)
-  local plugin = require(plugin_name)
-  if plugin ~= nil then
+  local status, err = pcall(require, plugin_name)
+  if status then
     health.report_ok(plugin_name .. " is installed")
   else
     health.report_error(plugin_name .. " is missing")


### PR DESCRIPTION
Problem

If either of the required dependencies for `treble`, `bufferline` or `telescope`, are missing, then running the *checkhealth* command for `treble` will cause an error. It displays a multiple line long trace of errors that somewhere in the middle shows that a particular module is missing. This is less than ideal.

Solution

For the *checkhealth* command, change loading of the required dependencies to load via `pcall` instead of loading via `require` directly. This allows for the ability to check for problems instead of them being immediately reported.

Result

The *checkhealth* command for `treble` is able to show in one line for each required dependency whether that dependency is available or not.